### PR TITLE
Print linting suggestions to stdout instead of stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func main() {
 	}
 
 	if *setExitStatus && suggestions > 0 {
-		fmt.Fprintf(os.Stderr, "Found %d lint suggestions; failing.\n", suggestions)
+		fmt.Printf("Found %d lint suggestions; failing.\n", suggestions)
 		os.Exit(1)
 	}
 }
@@ -127,7 +127,7 @@ func lintFiles(filenames ...string) {
 
 	for i := range files {
 		if err := plugins.Call(context.Background(), files[i]); err != nil {
-			fmt.Fprintf(os.Stderr, "%s => %v\n", i, err)
+			fmt.Printf("%s => %v\n", i, err)
 			suggestions++
 		}
 	}


### PR DESCRIPTION
Flint attempts to have the very same CLI as golint but I noticed it reports its suggestions to stderr instead of stdout. Note that actual error messages from flint are still send to stderr.